### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -52,6 +52,7 @@ class ObjectDB {
     this._data = [];
     bool firstLine = true;
     await reader
+        .cast<List<int>>()
         .transform(utf8.decoder)
         .transform(LineSplitter())
         .forEach((line) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: objectdb
 description: Persistent embedded document-oriented NoSQL database for Dart and Flutter.
-version: 1.0.7
+version: 1.0.7+1
 author: Mario Reggiori <dev@marioreggiori.com>
 homepage: https://github.com/marioreggiori/objectdb
 environment:


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900