### PR TITLE
Fix to open() method

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -162,6 +162,7 @@ class ObjectDB extends CRUDController {
         }
       }
     });
+    if (this._writer != null) await this._writer.close();
     this._writer = this._file.openWrite(mode: FileMode.writeOnlyAppend);
 
     if (oldVersion != null) {


### PR DESCRIPTION
Fix for bug similar to issue #20 - FileSystemException: Cannot rename file to '...test/test.db.bak', path = '...test/test.db' (OS Error: The process cannot access the file because it is being used by another process., errno = 32).

This fix makes the open(tidy: true) method more safe/flexible for other areas of the application besides just the main() method.  For instance, this fix prevents the above exception if the application happened to invoke open(tidy: true) multiple times consecutively without invoking the close() method in between.  There's also a chance that this bug could be the same as issue #26 as well.