### PR TITLE
accept null values as valid types and enhanced exception handling

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -501,7 +501,8 @@ class ObjectDB extends CRUDController {
           query[i] is double ||
           query[i] is bool ||
           query[i] is String ||
-          query[i] is List) {
+          query[i] is List ||
+          query[i] == null) {
         prepared[key] = query[i];
       } else {
         throw ObjectDBException("query contains invalid data type '${query[i]?.runtimeType}'");

--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -112,7 +112,7 @@ class ObjectDB extends CRUDController {
 
   /// Opens flat file database
   Future<ObjectDB> open([bool tidy = true]) {
-    return _executionQueue.add<ObjectDB>(() => this._open(tidy));
+    return _executionQueue.add<ObjectDB>(() => this._open(tidy)).catchError((exception) => Future.error(exception));
   }
 
   Future _open(bool tidy) async {
@@ -155,11 +155,7 @@ class ObjectDB extends CRUDController {
             return;
           }
         }
-        try {
-          this._fromFile(line);
-        } catch (e) {
-          // skip invalid line
-        }
+        this._fromFile(line);
       }
     });
     if (this._writer != null) await this._writer.close();
@@ -508,7 +504,7 @@ class ObjectDB extends CRUDController {
           query[i] is List) {
         prepared[key] = query[i];
       } else {
-        throw ObjectDBException('query contains invalid data types');
+        throw ObjectDBException("query contains invalid data type '${query[i]?.runtimeType}'");
       }
     }
     return prepared;


### PR DESCRIPTION
Fix for https://github.com/marioreggiori/objectdb/issues/40

In order to properly propagate the exception out of the `open()`-method a change to the `execution_queue`-library would be necessary. The change would be to change

```dart
item.completer.complete(await item.job());
```
to

```dart
try {
    var result = await item.job();
    item.completer.complete(result);
}catch(e){
    item.completer.completeError(e);
}
```

This is needed that the error of the job is propagated. Otherwise this leads to an "Unhandled exception" exception.