### PR TITLE
Parameterized the Future of open(..) to avoid cast errors in an error…

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -112,10 +112,10 @@ class ObjectDB extends CRUDController {
 
   /// Opens flat file database
   Future<ObjectDB> open([bool tidy = true]) {
-    return _executionQueue.add<ObjectDB>(() => this._open(tidy)).catchError((exception) => Future.error(exception));
+    return _executionQueue.add<ObjectDB>(() => this._open(tidy)).catchError((exception) => Future<ObjectDB>.error(exception));
   }
 
-  Future _open(bool tidy) async {
+  Future<ObjectDB> _open(bool tidy) async {
     var backupFile = File(this.path + '.bak');
     if (backupFile.existsSync()) {
       if (this._file.existsSync()) {


### PR DESCRIPTION
Hi,

There still exists a problem. Namely when an error occurs a casting exception happens. It says `Future<dynamic> cannot be cast to Future<ObjectDB>`. 
This is due to the missing generic parameters. See changes.

Regards,
Florian